### PR TITLE
upgrade to anyio 3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.6', '3.7', '3.8']  # 'pypy-3.6'
-        backend: [asyncio, curio, trio, uvloop]
+        backend: [asyncio, trio, uvloop]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        backend: [asyncio, curio, trio, uvloop]
+        backend: [asyncio, trio, uvloop]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 Asynchronous pure Python gRPC client and server implementation supporting
 [asyncio](https://docs.python.org/3/library/asyncio.html),
 [uvloop](https://github.com/MagicStack/uvloop),
-[curio](https://github.com/dabeaz/curio) and
 [trio](https://github.com/python-trio/trio) (achieved with [anyio](https://github.com/agronholm/anyio) compatibility layer).
 
 ## Requirements
@@ -29,7 +28,7 @@ Latest development version:
 pip install git+https://github.com/standy66/purerpc.git
 ```
 
-By default purerpc uses asyncio event loop, if you want to use uvloop, curio or trio, please install them manually.
+By default purerpc uses asyncio event loop, if you want to use uvloop or trio, please install them manually.
 
 ## protoc plugin
 
@@ -57,9 +56,9 @@ Just mark yielding coroutines with `@async_generator` decorator and use `await y
 ### Server
 
 ```python
+from purerpc import Server
 from greeter_pb2 import HelloRequest, HelloReply
 from greeter_grpc import GreeterServicer
-from purerpc import Server
 
 
 class Greeter(GreeterServicer):
@@ -71,15 +70,17 @@ class Greeter(GreeterServicer):
             yield HelloReply(message=f"Hello, {message.name}")
 
 
-server = Server(50055)
-server.add_service(Greeter().service)
-server.serve(backend="asyncio")  # backend can also be one of: "uvloop", "curio", "trio"
+if __name__ == '__main__':
+    server = Server(50055)
+    server.add_service(Greeter().service)
+    # NOTE: if you already have an async loop running, use "await server.serve_async()"
+    import anyio
+    anyio.run(server.serve_async)  # or set explicit backend="asyncio" or "trio"
 ```
 
 ### Client
 
 ```python
-import anyio
 import purerpc
 from greeter_pb2 import HelloRequest, HelloReply
 from greeter_grpc import GreeterStub
@@ -90,7 +91,7 @@ async def gen():
         yield HelloRequest(name=str(i))
 
 
-async def main():
+async def listen():
     async with purerpc.insecure_channel("localhost", 50055) as channel:
         stub = GreeterStub(channel)
         reply = await stub.SayHello(HelloRequest(name="World"))
@@ -100,8 +101,10 @@ async def main():
             print(reply.message)
 
 
-if __name__ == "__main__":
-    anyio.run(main, backend="asyncio")  # backend can also be one of: "uvloop", "curio", "trio"
+if __name__ == '__main__':
+    # NOTE: if you already have an async loop running, use "await listen()"
+    import anyio
+    anyio.run(listen)  # or set explicit backend="asyncio" or "trio"
 ```
 
 You can mix server and client code, for example make a server that requests something using purerpc from another gRPC server, etc.

--- a/misc/greeter/client.py
+++ b/misc/greeter/client.py
@@ -16,13 +16,12 @@ async def worker(channel):
 
 
 async def main_coro():
-    # await curio.spawn(print_memory_growth_statistics(), daemon=True)
     async with purerpc.insecure_channel("localhost", 50055) as channel:
         for _ in range(100):
             start = time.time()
             async with anyio.create_task_group() as task_group:
                 for _ in range(100):
-                    await task_group.spawn(worker, channel)
+                    task_group.start_soon(worker, channel)
             print("RPS: {}".format(10000 / (time.time() - start)))
 
 

--- a/misc/greeter/test_perf.py
+++ b/misc/greeter/test_perf.py
@@ -29,7 +29,7 @@ async def do_load_unary(result_queue, stub, num_requests, message_size):
         result = (await stub.SayHello(HelloRequest(name=message))).message
         assert (len(result) == message_size)
     avg_latency = (time.time() - start) / num_requests
-    await result_queue.put(avg_latency)
+    await result_queue.send(avg_latency)
 
 
 async def do_load_stream(result_queue, stub, num_requests, message_size):
@@ -43,7 +43,7 @@ async def do_load_stream(result_queue, stub, num_requests, message_size):
     avg_latency = (time.time() - start) / num_requests
     await stream.close()
     await stream.receive_message()
-    await result_queue.put(avg_latency)
+    await result_queue.send(avg_latency)
 
 
 async def worker(port, queue, num_concurrent_streams, num_requests_per_stream,
@@ -58,16 +58,16 @@ async def worker(port, queue, num_concurrent_streams, num_requests_per_stream,
             raise ValueError(f"Unknown load type: {load_type}")
         for _ in range(num_rounds):
             start = time.time()
-            task_results = anyio.create_queue(sys.maxsize)
+            send_queue, receive_queue = anyio.create_memory_object_stream(max_buffer_size=sys.maxsize)
             async with anyio.create_task_group() as task_group:
                 for _ in range(num_concurrent_streams):
-                    await task_group.spawn(load_fn, task_results, stub, num_requests_per_stream, message_size)
+                    task_group.start_soon(load_fn, send_queue, stub, num_requests_per_stream, message_size)
             end = time.time()
             rps = num_concurrent_streams * num_requests_per_stream / (end - start)
             queue.put(rps)
             results = []
             for _ in range(num_concurrent_streams):
-                results.append(await task_results.get())
+                results.append(await receive_queue.receive())
             queue.put(results)
         queue.close()
         queue.join_thread()

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,13 +4,12 @@
 #
 #    pip-compile --extra=test --output-file=requirements_test.txt setup.py
 #
-anyio==1.4.0
+anyio==3.5.0
     # via purerpc (setup.py)
 async-exit-stack==1.0.1
     # via purerpc (setup.py)
 async-generator==1.10
     # via
-    #   anyio
     #   purerpc (setup.py)
     #   trio
 attrs==21.4.0
@@ -18,8 +17,6 @@ attrs==21.4.0
     #   outcome
     #   pytest
     #   trio
-curio==1.5
-    # via purerpc (setup.py)
 grpcio==1.44.0
     # via
     #   grpcio-tools
@@ -75,7 +72,9 @@ tomli==2.0.1
 trio==0.20.0
     # via purerpc (setup.py)
 typing-extensions==4.1.1
-    # via importlib-metadata
+    # via
+    #   anyio
+    #   importlib-metadata
 uvloop==0.16.0
     # via purerpc (setup.py)
 zipp==3.8.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -17,6 +17,10 @@ attrs==21.4.0
     #   outcome
     #   pytest
     #   trio
+cffi==1.15.0
+    # via cryptography
+cryptography==36.0.2
+    # via trustme
 grpcio==1.44.0
     # via
     #   grpcio-tools
@@ -33,6 +37,7 @@ idna==3.3
     # via
     #   anyio
     #   trio
+    #   trustme
 importlib-metadata==4.11.3
     # via
     #   pluggy
@@ -51,6 +56,8 @@ protobuf==3.20.0
     #   purerpc (setup.py)
 py==1.11.0
     # via pytest
+pycparser==2.21
+    # via cffi
 pyparsing==3.0.8
     # via packaging
 pytest==7.1.1
@@ -70,6 +77,8 @@ tblib==1.7.0
 tomli==2.0.1
     # via pytest
 trio==0.20.0
+    # via purerpc (setup.py)
+trustme==0.9.0
     # via purerpc (setup.py)
 typing-extensions==4.1.1
     # via

--- a/requirements_test_py36.txt
+++ b/requirements_test_py36.txt
@@ -17,11 +17,15 @@ attrs==21.4.0
     #   outcome
     #   pytest
     #   trio
+cffi==1.15.0
+    # via cryptography
 contextvars==2.4
     # via
     #   anyio
     #   sniffio
     #   trio
+cryptography==36.0.2
+    # via trustme
 dataclasses==0.8
     # via anyio
 grpcio==1.44.0
@@ -40,6 +44,7 @@ idna==3.3
     # via
     #   anyio
     #   trio
+    #   trustme
 immutables==0.17
     # via contextvars
 importlib-metadata==4.8.3
@@ -60,6 +65,8 @@ protobuf==3.19.4
     #   purerpc (setup.py)
 py==1.11.0
     # via pytest
+pycparser==2.21
+    # via cffi
 pyparsing==3.0.8
     # via packaging
 pytest==7.0.1
@@ -79,6 +86,8 @@ tblib==1.7.0
 tomli==1.2.3
     # via pytest
 trio==0.19.0
+    # via -r requirements_test.in
+trustme==0.9.0
     # via -r requirements_test.in
 typing-extensions==4.1.1
     # via

--- a/requirements_test_py36.txt
+++ b/requirements_test_py36.txt
@@ -4,13 +4,12 @@
 #
 #    pip-compile --output-file=requirements_test_py36.txt requirements_test.in setup.py
 #
-anyio==1.4.0
+anyio==3.5.0
     # via purerpc (setup.py)
 async-exit-stack==1.0.1
     # via purerpc (setup.py)
 async-generator==1.10
     # via
-    #   anyio
     #   purerpc (setup.py)
     #   trio
 attrs==21.4.0
@@ -20,10 +19,11 @@ attrs==21.4.0
     #   trio
 contextvars==2.4
     # via
+    #   anyio
     #   sniffio
     #   trio
-curio==1.4
-    # via -r requirements_test.in
+dataclasses==0.8
+    # via anyio
 grpcio==1.44.0
     # via
     #   -r requirements_test.in
@@ -82,6 +82,7 @@ trio==0.19.0
     # via -r requirements_test.in
 typing-extensions==4.1.1
     # via
+    #   anyio
     #   immutables
     #   importlib-metadata
 uvloop==0.14.0

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ def main():
                 "uvloop",
                 "trio>=0.11",
                 "python-forge>=18.6",
+                "trustme",
             ]
         },
     )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def main():
         version=__version__,
         license="Apache License Version 2.0",
         description=("Asynchronous pure Python gRPC client and server implementation "
-                     "supporting asyncio, uvloop, curio and trio"),
+                     "supporting asyncio, uvloop, trio"),
         long_description='%s\n%s' % (
             re.compile('^.. start-badges.*^.. end-badges', re.M | re.S).sub('', read('README.md')),
             re.sub(':[a-z]+:`~?(.*?)`', r'``\1``', read('RELEASE.md'))
@@ -64,7 +64,7 @@ def main():
         install_requires=[
             "h2>=3.1.0,<4",
             "protobuf>=3.5.1",
-            "anyio>=1.0.0,<2",  # TODO: anyio 3.x upgrade
+            "anyio>=3.0.0",
             "async_exit_stack>=1.0.1",
             "tblib>=1.3.2",
             "async_generator>=1.10",
@@ -79,7 +79,6 @@ def main():
                 "grpcio_tools>=1.25.0",     # same here
                 "uvloop",
                 "trio>=0.11",
-                "curio>=0.9",
                 "python-forge>=18.6",
             ]
         },

--- a/src/purerpc/client.py
+++ b/src/purerpc/client.py
@@ -15,14 +15,14 @@ class _Channel(async_exit_stack.AsyncExitStack):
         super().__init__()
         self._host = host
         self._port = port
-        self._ssl = ssl_context
+        self._ssl_context = ssl_context
         self._grpc_socket = None
 
     async def __aenter__(self):
         await super().__aenter__()  # Does nothing
         socket = await anyio.connect_tcp(self._host, self._port,
-                                         ssl_context=self._ssl,
-                                         tls=self._ssl is not None,
+                                         ssl_context=self._ssl_context,
+                                         tls=self._ssl_context is not None,
                                          tls_standard_compatible=False)
         config = GRPCConfiguration(client_side=True)
         self._grpc_socket = await self.enter_async_context(GRPCProtoSocket(config, socket))

--- a/src/purerpc/client.py
+++ b/src/purerpc/client.py
@@ -22,7 +22,7 @@ class _Channel(async_exit_stack.AsyncExitStack):
         await super().__aenter__()  # Does nothing
         socket = await anyio.connect_tcp(self._host, self._port,
                                          ssl_context=self._ssl,
-                                         autostart_tls=self._ssl is not None,
+                                         tls=self._ssl is not None,
                                          tls_standard_compatible=False)
         config = GRPCConfiguration(client_side=True)
         self._grpc_socket = await self.enter_async_context(GRPCProtoSocket(config, socket))

--- a/src/purerpc/grpc_socket.py
+++ b/src/purerpc/grpc_socket.py
@@ -88,6 +88,7 @@ class GRPCStream:
         self._grpc_socket = grpc_socket
         self._socket = socket
         self._flow_control_update_event = anyio.Event()
+        # TODO: find a reasonable buffer size, or expose it in the API
         self._incoming_events = anyio.create_memory_object_stream(max_buffer_size=sys.maxsize)  # (send, receive)
         self._response_started = False
         self._state = GRPCStreamState.OPEN

--- a/src/purerpc/grpc_socket.py
+++ b/src/purerpc/grpc_socket.py
@@ -18,10 +18,10 @@ from .grpclib.exceptions import StreamClosedError
 
 
 class SocketWrapper(async_exit_stack.AsyncExitStack):
-    def __init__(self, grpc_connection: GRPCConnection, sock: anyio.abc.SocketStream):
+    def __init__(self, grpc_connection: GRPCConnection, stream: anyio.abc.SocketStream):
         super().__init__()
-        self._set_socket_options(sock)
-        self._socket = sock
+        self._set_socket_options(stream)
+        self._stream = stream
         self._grpc_connection = grpc_connection
         self._flush_event = anyio.Event()
         self._running = True
@@ -57,7 +57,7 @@ class SocketWrapper(async_exit_stack.AsyncExitStack):
         while True:
             data = self._grpc_connection.data_to_send()
             if data:
-                await self._socket.send(data)
+                await self._stream.send(data)
             elif self._running:
                 await self._flush_event.wait()
                 self._flush_event = anyio.Event()
@@ -70,7 +70,7 @@ class SocketWrapper(async_exit_stack.AsyncExitStack):
 
     async def recv(self, buffer_size: int):
         """This may only be called from single thread."""
-        return await self._socket.receive(buffer_size)
+        return await self._stream.receive(buffer_size)
 
 
 class GRPCStreamState(enum.Enum):

--- a/src/purerpc/rpc.py
+++ b/src/purerpc/rpc.py
@@ -1,6 +1,7 @@
 import enum
 import typing
 import collections
+import collections.abc
 
 
 Stream = typing.AsyncIterator

--- a/src/purerpc/test_utils.py
+++ b/src/purerpc/test_utils.py
@@ -118,15 +118,15 @@ def _run_context_manager_generator_in_process(cm_gen):
             parent_conn.close()
 
 
-def run_purerpc_service_in_process(service):
+def run_purerpc_service_in_process(service, port=50055, ssl_context=None):
+    # port cannot be 0 since we have to yield the port number before serve()
     # TODO: migrate to an async context manager and serve_async().
     #  This async cm has timing problems, because the server may not
     #  be listening before yielding to the body.
 
     def target_fn():
         import purerpc
-        port = 50055
-        server = purerpc.Server(port=port)
+        server = purerpc.Server(port=port, ssl_context=ssl_context)
         server.add_service(service)
         yield port
         server.serve()

--- a/src/purerpc/wrappers.py
+++ b/src/purerpc/wrappers.py
@@ -103,7 +103,7 @@ class ClientStubStreamUnary(ClientStub):
     async def __call__(self, message_aiter, *, metadata=None):
         stream = await self._stream_fn(metadata=metadata)
         async with anyio.create_task_group() as task_group:
-            await task_group.spawn(send_multiple_messages_client, stream, message_aiter)
+            task_group.start_soon(send_multiple_messages_client, stream, message_aiter)
             return await extract_message_from_singleton_stream(stream)
 
 
@@ -112,7 +112,7 @@ class ClientStubStreamStream(ClientStub):
     async def call_aiter(self, message_aiter, metadata):
         stream = await self._stream_fn(metadata=metadata)
         async with anyio.create_task_group() as task_group:
-            await task_group.spawn(send_multiple_messages_client, stream, message_aiter)
+            task_group.start_soon(send_multiple_messages_client, stream, message_aiter)
             await yield_from_(stream_to_async_iterator(stream))
 
     async def call_stream(self, metadata):

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -95,7 +95,6 @@ def purerpc_echo_port_ssl(echo_pb2, echo_grpc, server_ssl_context):
             await yield_(echo_pb2.EchoReply(data="".join(data)))
 
     with run_purerpc_service_in_process(Servicer().service,
-                                        port=50056,
                                         ssl_context=server_ssl_context) as port:
         # TODO: migrate to serve_async() to avoid timing problems
         import time

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -1,10 +1,32 @@
 import functools
+import ssl
 
 import pytest
+import trustme
 from async_generator import async_generator, yield_
 
+import purerpc
 from purerpc.test_utils import run_purerpc_service_in_process, run_grpc_service_in_process, \
     async_iterable_to_list, random_payload, grpc_client_parallelize, async_test, purerpc_channel, purerpc_client_parallelize, grpc_channel
+
+
+@pytest.fixture(scope='module')
+def ca():
+    return trustme.CA()
+
+
+@pytest.fixture(scope='module')
+def server_ssl_context(ca):
+    server_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    ca.issue_cert('127.0.0.1').configure_cert(server_context)
+    return server_context
+
+
+@pytest.fixture(scope='module')
+def client_ssl_context(ca):
+    client_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    ca.configure_trust(client_context)
+    return client_context
 
 
 @pytest.fixture(scope="module")
@@ -37,6 +59,44 @@ def purerpc_echo_port(echo_pb2, echo_grpc):
             await yield_(echo_pb2.EchoReply(data="".join(data)))
 
     with run_purerpc_service_in_process(Servicer().service) as port:
+        # TODO: migrate to serve_async() to avoid timing problems
+        import time
+        time.sleep(.1)
+        yield port
+
+
+@pytest.fixture(scope="module")
+def purerpc_echo_port_ssl(echo_pb2, echo_grpc, server_ssl_context):
+    class Servicer(echo_grpc.EchoServicer):
+        async def Echo(self, message):
+            return echo_pb2.EchoReply(data=message.data)
+
+        @async_generator
+        async def EchoTwoTimes(self, message):
+            await yield_(echo_pb2.EchoReply(data=message.data))
+            await yield_(echo_pb2.EchoReply(data=message.data))
+
+        @async_generator
+        async def EchoEachTime(self, messages):
+            async for message in messages:
+                await yield_(echo_pb2.EchoReply(data=message.data))
+
+        async def EchoLast(self, messages):
+            data = []
+            async for message in messages:
+                data.append(message.data)
+            return echo_pb2.EchoReply(data="".join(data))
+
+        @async_generator
+        async def EchoLastV2(self, messages):
+            data = []
+            async for message in messages:
+                data.append(message.data)
+            await yield_(echo_pb2.EchoReply(data="".join(data)))
+
+    with run_purerpc_service_in_process(Servicer().service,
+                                        port=50056,
+                                        ssl_context=server_ssl_context) as port:
         # TODO: migrate to serve_async() to avoid timing problems
         import time
         time.sleep(.1)
@@ -139,3 +199,19 @@ async def test_purerpc_client_deadlock(echo_pb2, echo_grpc, channel):
 
     assert [response.data for response in await async_iterable_to_list(
             stub.EchoLastV2(gen()))] == [data * 20]
+
+
+@async_test
+async def test_purerpc_ssl(echo_pb2, echo_grpc, purerpc_echo_port_ssl, client_ssl_context):
+    async with purerpc.secure_channel("127.0.0.1", purerpc_echo_port_ssl,
+                                      ssl_context=client_ssl_context) as channel:
+        stub = echo_grpc.EchoStub(channel)
+        data = random_payload(min_size=32000, max_size=64000)
+
+        @async_generator
+        async def gen():
+            for _ in range(20):
+                await yield_(echo_pb2.EchoRequest(data=data))
+
+        assert [response.data for response in await async_iterable_to_list(
+                stub.EchoLastV2(gen()))] == [data * 20]

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -37,6 +37,9 @@ def purerpc_echo_port(echo_pb2, echo_grpc):
             await yield_(echo_pb2.EchoReply(data="".join(data)))
 
     with run_purerpc_service_in_process(Servicer().service) as port:
+        # TODO: migrate to serve_async() to avoid timing problems
+        import time
+        time.sleep(.1)
         yield port
 
 

--- a/tests/test_server_http2.py
+++ b/tests/test_server_http2.py
@@ -17,6 +17,8 @@ from purerpc.test_utils import run_purerpc_service_in_process
 @pytest.fixture
 def dummy_server_port():
     with run_purerpc_service_in_process(purerpc.Service("Greeter")) as port:
+        # TODO: migrate to serve_async() to avoid timing problems
+        time.sleep(0.1)
         yield port
 
 
@@ -35,7 +37,7 @@ def http2_client_connect(host, port):
         sock.close()
 
 
-def http2_receive_events(conn, sock, timeout=0.1):
+def http2_receive_events(conn, sock):
     try:
         sock.settimeout(0.1)
         events = []


### PR DESCRIPTION
Upgrade to anyio 3.x API, which implies dropping Curio support.

Along the way:
  * introduce Server.serve_async().  Use of serve() is strongly
    discouraged because it runs a full event loop.
  * add ssl test coverage
  * tests use an ephemeral port
  * update example in README.  Don't encourage passing
    backend='uvloop' to anyio.run(), since it relies on runtime
    patching.

Fixes #31 