### PR TITLE
fix Sever handling of end-of-stream condition

### DIFF
--- a/src/purerpc/grpc_socket.py
+++ b/src/purerpc/grpc_socket.py
@@ -233,6 +233,9 @@ class GRPCSocket(AsyncExitStack):
         while True:
             try:
                 data = await self._socket.recv(self._receive_buffer_size)
+            # TODO: Not too confident that BrokenResourceError should be treated
+            #  the same as EndOfStream (maybe the handler wants to know?), but it's
+            #  here for parity with anyio 1.x behavior.
             except (anyio.EndOfStream, anyio.BrokenResourceError):
                 return
             events = self._grpc_connection.receive_data(data)

--- a/src/purerpc/grpc_socket.py
+++ b/src/purerpc/grpc_socket.py
@@ -231,8 +231,9 @@ class GRPCSocket(AsyncExitStack):
 
     async def _listen(self):
         while True:
-            data = await self._socket.recv(self._receive_buffer_size)
-            if not data:
+            try:
+                data = await self._socket.recv(self._receive_buffer_size)
+            except (anyio.EndOfStream, anyio.BrokenResourceError):
                 return
             events = self._grpc_connection.receive_data(data)
             await self._socket.flush()

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -196,11 +196,11 @@ async def test_purerpc_client_disconnect(echo_pb2, echo_grpc):
     # NOTE: This test demonstrates a client/server test without multiprocessing or
     #  fixture acrobatics.
 
-    # server
-    Servicer = make_servicer(echo_pb2, echo_grpc)
-    server = purerpc.Server(port=0)
-    server.add_service(Servicer().service)
     async with anyio.create_task_group() as tg:
+        # server
+        Servicer = make_servicer(echo_pb2, echo_grpc)
+        server = purerpc.Server(port=0)
+        server.add_service(Servicer().service)
         port = await tg.start(server.serve_async)
 
         # client


### PR DESCRIPTION
anyio 2.x changed from returning empty data to raising
EndOfStream.  Prior to the anyio upgrade, no tests raised an
exception the server main loop, while after there were many
instances of EndOfStream and BrokenResourceError.

Also fix apparent bug in server connection handler, where the
wrong socket might be used.