### PR TITLE
Wrap bidirectional streaming requests in context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ async def listen():
         reply = await stub.SayHello(HelloRequest(name="World"))
         print(reply.message)
 
-        async for reply in stub.SayHelloToMany(gen()):
-            print(reply.message)
+        async with stub.SayHelloToMany(gen()) as stream:
+            async for reply in stream:
+                print(reply.message)
 
 
 if __name__ == '__main__':

--- a/tests/test_echo.py
+++ b/tests/test_echo.py
@@ -148,8 +148,10 @@ async def test_purerpc_client_random_payload(echo_pb2, echo_grpc, channel):
     assert [response.data for response in await async_iterable_to_list(
             stub.EchoTwoTimes(echo_pb2.EchoRequest(data=data)))] == [data] * 2
     assert (await stub.EchoLast(gen())).data == data * 4
-    assert [response.data for response in await async_iterable_to_list(
-            stub.EchoEachTime(gen()))] == [data] * 4
+    async with stub.EchoEachTime(gen()) as aiter:
+        assert [response.data for response in await async_iterable_to_list(aiter)] == [
+            data
+        ] * 4
 
 
 @purerpc_channel("echo_port")
@@ -162,8 +164,10 @@ async def test_purerpc_client_deadlock(echo_pb2, echo_grpc, channel):
         for _ in range(20):
             yield echo_pb2.EchoRequest(data=data)
 
-    assert [response.data for response in await async_iterable_to_list(
-            stub.EchoLastV2(gen()))] == [data * 20]
+    async with stub.EchoLastV2(gen()) as aiter:
+        assert [response.data for response in await async_iterable_to_list(aiter)] == [
+            data * 20
+        ]
 
 
 async def test_purerpc_ssl(echo_pb2, echo_grpc, purerpc_echo_port_ssl, client_ssl_context):
@@ -176,8 +180,10 @@ async def test_purerpc_ssl(echo_pb2, echo_grpc, purerpc_echo_port_ssl, client_ss
             for _ in range(20):
                 yield echo_pb2.EchoRequest(data=data)
 
-        assert [response.data for response in await async_iterable_to_list(
-                stub.EchoLastV2(gen()))] == [data * 20]
+        async with stub.EchoLastV2(gen()) as aiter:
+            assert [
+                response.data for response in await async_iterable_to_list(aiter)
+            ] == [data * 20]
 
 
 async def test_purerpc_client_disconnect(echo_pb2, echo_grpc):

--- a/tests/test_greeter.py
+++ b/tests/test_greeter.py
@@ -134,9 +134,10 @@ async def test_purerpc_stub_client_parallel(greeter_pb2, greeter_grpc, channel):
     assert [response.message for response in await async_iterable_to_list(
             stub.SayHelloGoodbye(greeter_pb2.HelloRequest(name="World")))] == ["Hello, World", "Goodbye, World"]
     assert (await stub.SayHelloToManyAtOnce(async_name_generator(greeter_pb2))).message == "Hello, Foo, Bar, Bat, Baz"
-    assert [response.message for response in await async_iterable_to_list(
-            stub.SayHelloToMany(async_name_generator(greeter_pb2)))] == \
-           ["Hello, Foo", "Hello, Bar", "Hello, Bat", "Hello, Baz"]
+    async with stub.SayHelloToMany(async_name_generator(greeter_pb2)) as aiter:
+        assert [
+            response.message for response in await async_iterable_to_list(aiter)
+        ] == ["Hello, Foo", "Hello, Bar", "Hello, Bat", "Hello, Baz"]
 
 
 @purerpc_channel("greeter_port")


### PR DESCRIPTION
This client API change wraps bidirectional streaming requests in a context manager.

Bidirectional streams need to be able to spawn a task group to keep sending messages from the client to the server while the client is processing one of the messages of the server. In order to prevent corruption of the task group stack, task groups cannot wrap yield statements in generators. This is fixed by creating the task group in a context manager and yielding the generator for the server message from that context manager.

Fixes #36