### PR TITLE
Improve test performance

### DIFF
--- a/src/purerpc/test_utils.py
+++ b/src/purerpc/test_utils.py
@@ -88,8 +88,9 @@ async def async_iterable_to_list(async_iterable):
 
 
 def random_payload(min_size=1000, max_size=100000):
-    return "".join(random.choice(string.ascii_letters)
-                   for _ in range(random.randint(min_size, max_size)))
+    return "".join(
+        random.choices(string.ascii_letters, k=random.randint(min_size, max_size))
+    )
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Replacing the loop of random.choice in test_utils.random_payload by random.choices improves performance of the tests significantly.

- before

  Time (mean ± σ):     13.433 s ±  0.251 s    [User: 15.041 s, System: 3.470 s]
  Range (min … max):   13.029 s … 13.785 s    10 runs

- after

  Time (mean ± σ):     10.305 s ±  0.152 s    [User: 11.898 s, System: 3.448 s]
  Range (min … max):   10.017 s … 10.573 s    10 runs