### PR TITLE
feat: code gen produces same imports as grpcio

### DIFF
--- a/src/purerpc/protoc_plugin/plugin.py
+++ b/src/purerpc/protoc_plugin/plugin.py
@@ -10,7 +10,11 @@ from purerpc import Cardinality
 def generate_import_statement(proto_name):
     module_path = proto_name[:-len(".proto")].replace("-", "_").replace("/", ".") + "_pb2"
     alias = get_python_module_alias(proto_name)
-    return "import " + module_path + " as " + alias
+    if "." in module_path:
+        parent_modules, sub_module = module_path.rsplit(".", 1)
+        return "from " + parent_modules + " import " + sub_module + " as " + alias
+    else:
+        return "import " + module_path + " as " + alias
 
 
 def get_python_module_alias(proto_name):

--- a/src/purerpc/protoc_plugin/plugin.py
+++ b/src/purerpc/protoc_plugin/plugin.py
@@ -11,6 +11,9 @@ def generate_import_statement(proto_name):
     module_path = proto_name[:-len(".proto")].replace("-", "_").replace("/", ".") + "_pb2"
     alias = get_python_module_alias(proto_name)
     if "." in module_path:
+        # produces import statements in line with grpcio so that tools for 
+        # postprocessing import statements work with purerpc as well
+        # example: `from foo.bar import zap_pb2 as foo_dot_bar_dot_zap__pb2`
         parent_modules, sub_module = module_path.rsplit(".", 1)
         return "from " + parent_modules + " import " + sub_module + " as " + alias
     else:


### PR DESCRIPTION
without this change purerpc produces import statements of the form

`import foo.bar.some_pb2 as foo_dot_bar_dot_some__pb2`

whereas grpcio would produce

`from foo.bar import some_pb2 as foo_dot_bar_dot_some__pb2`

While equivalent where the import system is concerned, some tools and scripts exist for automatically fixing generated import statements (see for example https://github.com/cpcloud/protoletariat). These only work for import statements written in the latter form.